### PR TITLE
Fixed requirements.txt format for MacOS & Python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,24 @@
-Package             Version  
-------------------- ---------
-certifi             2021.5.30
-chardet             4.0.0    
-click               8.0.0    
-colorama            0.4.4    
-Flask               2.0.0    
-Flask-Login         0.5.0    
-idna                2.10     
-iteration-utilities 0.11.0   
-itsdangerous        2.0.0    
-Jinja2              3.0.0    
-MarkupSafe          2.0.0    
-ndjson              0.3.1    
-numpy               1.21.0   
-pandas              1.3.0    
-pip                 19.2.3   
-python-dateutil     2.8.1    
-python-dotenv       0.17.1   
-python-oauth2       1.1.1    
-pytz                2021.1   
-requests            2.25.1   
-setuptools          41.2.0   
-six                 1.16.0   
-urllib3             1.26.5   
-Werkzeug            2.0.0    
+certifi == 2021.5.30
+chardet == 4.0.0
+click == 8.0.0
+colorama == 0.4.4
+Flask == 2.0.0
+Flask_Login == 0.5.0
+idna == 2.10
+iteration_utilities == 0.11.0
+itsdangerous == 2.0.0
+Jinja2 == 3.0.0
+MarkupSafe == 2.0.0
+ndjson == 0.3.1
+numpy == 1.21.0
+pandas == 1.3.0
+pip == 19.2.3
+python_dateutil == 2.8.1
+python_dotenv == 0.17.1
+python_oauth2 == 1.1.1
+pytz == 2021.1
+requests == 2.25.1
+setuptools == 41.2.0
+six == 1.16.0
+urllib3 == 1.26.5
+Werkzeug == 2.0.0


### PR DESCRIPTION
The verbose format did not work with `pip install -r requirements.txt` command.
I am working on MacOS (11.15.5) and Python 3.9.6 .